### PR TITLE
修正後台登出失敗問題

### DIFF
--- a/src/Module/Admin/Auth/AuthController.php
+++ b/src/Module/Admin/Auth/AuthController.php
@@ -73,9 +73,7 @@ class AuthController
 
     public function logout(UserService $userService, Navigator $nav): RouteUri
     {
-        $user = $userService->getUser();
-
-        $userService->logout($user);
+        $userService->logout();
 
         return $nav->to('login');
     }

--- a/src/Module/Admin/Auth/AuthController.php
+++ b/src/Module/Admin/Auth/AuthController.php
@@ -73,7 +73,9 @@ class AuthController
 
     public function logout(UserService $userService, Navigator $nav): RouteUri
     {
-        $userService->logout();
+        $user = $userService->getUser();
+
+        $userService->logout($user);
 
         return $nav->to('login');
     }

--- a/src/User/Handler/UserHandler.php
+++ b/src/User/Handler/UserHandler.php
@@ -126,9 +126,8 @@ class UserHandler implements UserHandlerInterface
 
         $session->start();
 
-        // $session->destroy();
-        // Restart will also delete old session
-        $session->restart();
+        $session->destroy();
+        $session->regenerate(false, false);
 
         $this->cacheReset();
 


### PR DESCRIPTION
如題,

在authController logout時沒將 user 丟進 `logout()` 內 導致登出失敗