### PR TITLE
Fixed lang assoc field, middleware

### DIFF
--- a/src/Field/LocaleSwitchField.php
+++ b/src/Field/LocaleSwitchField.php
@@ -48,7 +48,7 @@ class LocaleSwitchField extends AbstractField
     protected bool $allowCreateEmpty = false;
 
     protected bool $canChangeSelfLang = true;
-    
+
     protected bool $showAllOption = true;
 
     #[Inject]

--- a/src/Field/LocaleSwitchField.php
+++ b/src/Field/LocaleSwitchField.php
@@ -48,6 +48,8 @@ class LocaleSwitchField extends AbstractField
     protected bool $allowCreateEmpty = false;
 
     protected bool $canChangeSelfLang = true;
+    
+    protected bool $showAllOption = true;
 
     #[Inject]
     protected AssociationService $associationService;
@@ -296,6 +298,26 @@ class LocaleSwitchField extends AbstractField
     public function allowCreateEmpty(bool $allowCreateEmpty): static
     {
         $this->allowCreateEmpty = $allowCreateEmpty;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isShowAllOption()
+    {
+        return $this->showAllOption;
+    }
+
+    /**
+     * @param  bool  $showAllOption
+     *
+     * @return  static  Return self to support chaining.
+     */
+    public function showAllOption(bool $showAllOption)
+    {
+        $this->showAllOption = $showAllOption;
 
         return $this;
     }

--- a/src/Middleware/LangAssocMiddleware.php
+++ b/src/Middleware/LangAssocMiddleware.php
@@ -52,6 +52,10 @@ class LangAssocMiddleware implements MiddlewareInterface
 
         $data = $request->getParsedBody()[$this->inputName] ?? null;
 
+        if (!$data) {
+            return $res;
+        }
+
         $task = $data['task'] ?? '';
 
         if ($task === 'create') {
@@ -179,7 +183,7 @@ class LangAssocMiddleware implements MiddlewareInterface
         return $this->nav->redirect($routeCallback($this->nav, $item));
     }
 
-    protected function refreshAssoc(array|null $data): void
+    protected function refreshAssoc(array $data): void
     {
         [
             'type' => $type,

--- a/src/Middleware/LangAssocMiddleware.php
+++ b/src/Middleware/LangAssocMiddleware.php
@@ -179,7 +179,7 @@ class LangAssocMiddleware implements MiddlewareInterface
         return $this->nav->redirect($routeCallback($this->nav, $item));
     }
 
-    protected function refreshAssoc(array $data): void
+    protected function refreshAssoc(array|null $data): void
     {
         [
             'type' => $type,

--- a/views/ui/bootstrap5/field/locale-switch.blade.php
+++ b/views/ui/bootstrap5/field/locale-switch.blade.php
@@ -60,8 +60,11 @@ $languageField->option(
     $lang('luna.field.locale.select.placeholder'),
     ''
 );
-$languageField->option($lang('luna.language.all'), '*');
-$languageField->setValue($value, '*');
+
+if ($field->isShowAllOption()) {
+    $languageField->option($lang('luna.language.all'), '*');
+    $languageField->setValue($value, '*');
+}
 ?>
 
 @if ($value && $currentLang)

--- a/views/ui/bootstrap5/field/locale-switch.blade.php
+++ b/views/ui/bootstrap5/field/locale-switch.blade.php
@@ -63,8 +63,9 @@ $languageField->option(
 
 if ($field->isShowAllOption()) {
     $languageField->option($lang('luna.language.all'), '*');
-    $languageField->setValue($value, '*');
 }
+
+$languageField->setValue($value, '*');
 ?>
 
 @if ($value && $currentLang)


### PR DESCRIPTION
修正 第一次儲存時 LangAssocMiddleware 中, refreshAssoc 參數為空的問題, 參數改為允許傳入 null 及 array 

LocaleSwitchField 新增一個 
showAllOption property 及 getter and setter用來開關所有語言的選項, 預設為 true

