### PR TITLE
[fix] user entity registered column

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -13,6 +13,7 @@ use Windwalker\ORM\Attributes\AutoIncrement;
 use Windwalker\ORM\Attributes\Cast;
 use Windwalker\ORM\Attributes\CastNullable;
 use Windwalker\ORM\Attributes\Column;
+use Windwalker\ORM\Attributes\CreatedTime;
 use Windwalker\ORM\Attributes\CurrentTime;
 use Windwalker\ORM\Attributes\EntitySetup;
 use Windwalker\ORM\Attributes\JsonObject;


### PR DESCRIPTION
User Entity 建立新用戶的時候發現，對註冊時間的column修復